### PR TITLE
Advanced Settings was showing twice

### DIFF
--- a/release/src/router/www/Advanced_VPN_OpenVPN.asp
+++ b/release/src/router/www/Advanced_VPN_OpenVPN.asp
@@ -1668,7 +1668,7 @@ function handle_ipv6_submit_settings(){
 									</div>
 									<div id="OpenVPN_setting" style="display:none;margin-top:8px;">
 										<div class="formfontdesc">
-											<#vpn_openvpn_desc1#>&nbsp;<#vpn_openvpn_desc3#>&nbsp;<#vpn_openvpn_desc2#> <#menu5#>
+											<#vpn_openvpn_desc1#>&nbsp;<#vpn_openvpn_desc3#>&nbsp;<#vpn_openvpn_desc2#>
 											<br />
 											<ol>
 												<li><a id="faq_windows" href="https://www.asus.com/support/FAQ/1004469/" target="_blank" style="text-decoration:underline;">Windows</a></li>


### PR DESCRIPTION
vpn_openvpn_desc2 already finish with Advanced Settings

Before
<img width="752" alt="image" src="https://github.com/gnuton/asuswrt-merlin.ng/assets/40678306/bdd200d1-803f-4083-81ee-5734df71aa6c">

After

<img width="758" alt="image" src="https://github.com/gnuton/asuswrt-merlin.ng/assets/40678306/48075cb2-90c2-4b58-9c2a-5f34ce11b1c1">
