### PR TITLE
Update merlin_webs_update.sh

### DIFF
--- a/release/src/router/rom/webs_scripts/merlin_webs_update.sh
+++ b/release/src/router/rom/webs_scripts/merlin_webs_update.sh
@@ -37,13 +37,13 @@ if [ "$?" != "0" ]; then
 	nvram set webs_state_error=1
 else
 
-	fullver=$(grep $model /tmp/wlan_update.txt | sed s/.*#FW//;)
+	fullver="$(grep "$model" /tmp/wlan_update.txt | tail -n1 | sed 's/.*#FW//')"
 	fullver=$(echo $fullver | sed s/#.*//;)
 	firmbase=$(echo $fullver | cut -d. -f1)
 	firmver=$(echo $fullver | cut -d. -f2)
 	buildno=$(echo $fullver | cut -d. -f3)
 
-	extendno=$(grep "$model" /tmp/wlan_update.txt | sed -n 's/.*#EXT\([0-9]*\).*/\1/p' | awk 'END {print}')
+	extendno="$(grep "$model" /tmp/wlan_update.txt | tail -n1 | sed 's/.*#EXT//')"
 	lextendno=$(echo $extendno | sed s/-g.*//;)
 
 	nvram set webs_state_info=${firmbase}_${firmver}_${buildno}_${extendno}

--- a/release/src/router/rom/webs_scripts/merlin_webs_update.sh
+++ b/release/src/router/rom/webs_scripts/merlin_webs_update.sh
@@ -44,6 +44,7 @@ else
 	buildno=$(echo $fullver | cut -d. -f3)
 
 	extendno="$(grep "$model" /tmp/wlan_update.txt | tail -n1 | sed 's/.*#EXT//')"
+	extendno=$(echo $extendno | sed s/#.*//;)
 	lextendno=$(echo $extendno | sed s/-g.*//;)
 
 	nvram set webs_state_info=${firmbase}_${firmver}_${buildno}_${extendno}

--- a/release/src/router/rom/webs_scripts/merlin_webs_update.sh
+++ b/release/src/router/rom/webs_scripts/merlin_webs_update.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -x;
+set -u;
 wget_options="-q -t 2 -T 30"
 
 fwsite="https://raw.githubusercontent.com/gnuton/asuswrt-merlin.ng/master/updates/"
@@ -43,8 +43,7 @@ else
 	firmver=$(echo $fullver | cut -d. -f2)
 	buildno=$(echo $fullver | cut -d. -f3)
 
-	extendno=$(grep $model /tmp/wlan_update.txt | sed s/.*#EXT//;)
-	extendno=$(echo $extendno | sed s/#.*//;)
+	extendno=$(grep "$model" /tmp/wlan_update.txt | sed -n 's/.*#EXT\([0-9]*\).*/\1/p' | awk 'END {print}')
 	lextendno=$(echo $extendno | sed s/-g.*//;)
 
 	nvram set webs_state_info=${firmbase}_${firmver}_${buildno}_${extendno}


### PR DESCRIPTION
Allow Support for MerlinAU AMTM Addon.

Currently the **webs_update.sh** script located on Gnuton firmware in the following directory `/usr/sbin/webs_update.sh` has errors which make it incompatible with MerlinAU as found below when testing:

[https://pastebin.com/raw/QEwGw2u8](https://pastebin.com/raw/QEwGw2u8)

The errors indicate the **webs_update** script is unable to complete on your users router due to: 
`Input cmd:2-gnuton1 is not supported`

![image](https://github.com/gnuton/asuswrt-merlin.ng/assets/1971404/be29fcec-b459-47a2-9f58-b3d37a868bb6)
![image (1)](https://github.com/gnuton/asuswrt-merlin.ng/assets/1971404/2f852444-0c55-4e4e-8af4-a32028ada4d8)

Resolving the issue includes disabling debug mode for the script so it can be called from MerlinAU without printing to console, and also to simplify the extendno sorting as the issue lies here:

```
    extendno=$(grep $model /tmp/wlan_update.txt | sed s/.*#EXT//;)
    extendno=$(echo $extendno | sed s/#.*//;)
    lextendno=$(echo $extendno | sed s/-g.*//;)
```

**If I replace it to:**

```
	fullver="$(grep "$model" /tmp/wlan_update.txt | tail -n1 | sed 's/.*#FW//')"
	fullver=$(echo $fullver | sed s/#.*//;)
	firmbase=$(echo $fullver | cut -d. -f1)
	firmver=$(echo $fullver | cut -d. -f2)
	buildno=$(echo $fullver | cut -d. -f3)

	extendno="$(grep "$model" /tmp/wlan_update.txt | tail -n1 | sed 's/.*#EXT//')"
```

Which deals with the error.