### PR TITLE
Fix RT-AX82U RGB reset issue by ensuring ledg is running

### DIFF
--- a/release/src/router/rc/services.c
+++ b/release/src/router/rc/services.c
@@ -20982,6 +20982,10 @@ void setup_leds()
 #endif
 
 #if defined(RTAX82U) || defined(GTAX11000_PRO) || defined(GTAXE16000) || defined(GTAX6000)
+		if (!pids("ledg")) {
+			start_ledg();
+			sleep(1);
+		}
 		kill_pidfile_s("/var/run/ledg.pid", SIGTSTP);
 #endif
 #if defined(XT12) || defined(ET12)

--- a/release/src/router/rc/services.c
+++ b/release/src/router/rc/services.c
@@ -20983,8 +20983,12 @@ void setup_leds()
 
 #if defined(RTAX82U) || defined(GTAX11000_PRO) || defined(GTAXE16000) || defined(GTAX6000)
 		if (!pids("ledg")) {
+			int i = 0;
 			start_ledg();
-			sleep(1);
+			while (i < 3 && !f_exists("/var/run/ledg.pid")) {
+				sleep(1);
+				i++;
+			}
 		}
 		kill_pidfile_s("/var/run/ledg.pid", SIGTSTP);
 #endif


### PR DESCRIPTION
The `ledg` service on RT-AX82U is responsible for LED effects. If not running, it gets restarted by watchdog, resetting LEDs to default. `setup_leds` attempts to pause `ledg` to allow `aurargb` (user settings) to take over, but if `ledg` isn't running yet (e.g. at boot), the pause fails.

This change ensures `ledg` is started if missing in `setup_leds` before attempting to pause it, preventing subsequent watchdog restarts and LED resets.