### PR TITLE
Prevent aaews crashloop in AP mode

### DIFF
--- a/release/src/router/rc/natnl_api.c
+++ b/release/src/router/rc/natnl_api.c
@@ -20,7 +20,7 @@ static int is_mesh_re_mode()
 
 void start_aae()
 {
-	if (is_mesh_re_mode())
+	if (is_mesh_re_mode() || access_point_mode())
 		return;
 
 	if(nvram_get_int("aae_disable_force"))
@@ -138,7 +138,7 @@ void start_mastiff()
 		return;
 #endif
 
-	if (is_mesh_re_mode())
+	if (is_mesh_re_mode() || access_point_mode())
 		return;
 
 	if(nvram_get_int("aae_disable_force"))

--- a/release/src/router/rc/services.c
+++ b/release/src/router/rc/services.c
@@ -18114,6 +18114,10 @@ retry_wps_enr:
 	{
 		setup_conntrack();
 		setup_udp_timeout(TRUE);
+#ifdef RTCONFIG_TUNNEL
+		if (nvram_get_int("aae_disable_force"))
+			stop_mastiff();
+#endif
 //            start_firewall(wan_primary_ifunit(), 0);
 	}
 	else if (strcmp(script, "leds") == 0) {


### PR DESCRIPTION
Prevent aaews crashloop in AP mode by checking for access point mode before starting services and ensuring they are stopped when disabled via WebUI.

---
*PR created automatically by Jules for task [17974206229778108027](https://jules.google.com/task/17974206229778108027) started by @gnuton*