### PR TITLE
Enable CONFIG_ADVISE_SYSCALLS for Broadcom HND platforms

### DIFF
--- a/release/src-rt-5.02L.07p2axhnd/hostTools/scripts/gendefconfig.d/15general.conf
+++ b/release/src-rt-5.02L.07p2axhnd/hostTools/scripts/gendefconfig.d/15general.conf
@@ -1207,8 +1207,8 @@ if ( $p->get('BUILD_LIBSECCOMP') ) {
 }
 
 #Docker kernel requirements
+$c->set( 'CONFIG_ADVISE_SYSCALLS', 'y' );
 if ( $p->get('BUILD_MODSW_DOCKEREE') ) {
-    $c->set( 'CONFIG_ADVISE_SYSCALLS', 'y' );
     $c->set( 'CONFIG_KEYS',            'y' );
     $c->set( 'CONFIG_POSIX_MQUEUE',    'y' );
 }

--- a/release/src-rt-5.02axhnd.675x/hostTools/scripts/gendefconfig.d/15general.conf
+++ b/release/src-rt-5.02axhnd.675x/hostTools/scripts/gendefconfig.d/15general.conf
@@ -1206,8 +1206,8 @@ if ( $p->get('BUILD_LIBSECCOMP') ) {
 }
 
 #Docker kernel requirements
+$c->set( 'CONFIG_ADVISE_SYSCALLS', 'y' );
 if ( $p->get('BUILD_MODSW_DOCKEREE') ) {
-    $c->set( 'CONFIG_ADVISE_SYSCALLS', 'y' );
     $c->set( 'CONFIG_KEYS',            'y' );
     $c->set( 'CONFIG_POSIX_MQUEUE',    'y' );
 }

--- a/release/src-rt-5.02axhnd/hostTools/scripts/gendefconfig.d/15general.conf
+++ b/release/src-rt-5.02axhnd/hostTools/scripts/gendefconfig.d/15general.conf
@@ -1049,8 +1049,8 @@ if ( $p->get( 'BUILD_LXC' ) || $p->get( 'BUILD_MODSW_DOCKEREE' ) ) {
 }
 
 #Docker kernel requirements
+$c->set( 'CONFIG_ADVISE_SYSCALLS', 'y' );
 if ( $p->get('BUILD_MODSW_DOCKEREE') ) {
-    $c->set( 'CONFIG_ADVISE_SYSCALLS', 'y' );
     $c->set( 'CONFIG_KEYS',            'y' );
     $c->set( 'CONFIG_POSIX_MQUEUE',    'y' );
 }

--- a/release/src-rt-5.04axhnd.675x/hostTools/scripts/gendefconfig.d/15general.conf
+++ b/release/src-rt-5.04axhnd.675x/hostTools/scripts/gendefconfig.d/15general.conf
@@ -1248,8 +1248,8 @@ if ( $p->get('BUILD_LIBSECCOMP') ) {
 }
 
 #Docker kernel requirements
+$c->set( 'CONFIG_ADVISE_SYSCALLS', 'y' );
 if ( $p->get('BUILD_MODSW_DOCKEREE') ) {
-    $c->set( 'CONFIG_ADVISE_SYSCALLS', 'y' );
     $c->set( 'CONFIG_KEYS',            'y' );
     $c->set( 'CONFIG_POSIX_MQUEUE',    'y' );
 }


### PR DESCRIPTION
This change enables the `CONFIG_ADVISE_SYSCALLS` kernel configuration option globally for Broadcom HND router platforms. This ensures that the `madvise()` and `fadvise()` system calls are available, which are required by user-space applications like the `bird2` routing daemon. Previously, this option was only enabled when `BUILD_MODSW_DOCKEREE` was set.

---
*PR created automatically by Jules for task [6076785811557389473](https://jules.google.com/task/6076785811557389473) started by @gnuton*