### PR TITLE
Restore manual firmware upload for DSL-AX82U ISP variants

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,7 +25,7 @@ jobs:
             - { model: "tuf-ax3000_v2", sdk: "src-rt-5.04axhnd.675x", ui: "tuf",      skip: false }
             - { model: "rt-ax58u_v2",   sdk: "src-rt-5.04axhnd.675x", ui: "default",  skip: false }
       container:
-        image: gnuton/asuswrt-merlin-toolchains-docker:latest-ubuntu-20_04
+        image: gnuton/asuswrt-merlin-toolchains-docker:latest
         env:
           MERLINUPDATE: "y"
           MODEL: ${{ matrix.cfg.model }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:          
     build-job:
       name: Build
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       strategy:
         fail-fast: false
         matrix:
@@ -188,7 +188,7 @@ jobs:
     release-job:
       name: Publish
       needs: build-job
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       if: startsWith(github.event.ref, 'refs/tags/')
       steps:
         - name: Download packages
@@ -212,7 +212,7 @@ jobs:
     manifest-job:
       name: Publish Manifest
       needs: build-job
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       if: startsWith(github.event.ref, 'refs/tags/') && !contains(github.event.ref, 'alpha') && !contains(github.event.ref, 'beta')
       steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -7,6 +7,7 @@ jobs:
       runs-on: ubuntu-22.04
       strategy:
         fail-fast: false
+        max-parallel: 2
         matrix:
           cfg:
             - { model: "rt-ax92u",      sdk: "src-rt-5.02axhnd",      ui: "default",  skip: false }
@@ -24,7 +25,7 @@ jobs:
             - { model: "tuf-ax3000_v2", sdk: "src-rt-5.04axhnd.675x", ui: "tuf",      skip: false }
             - { model: "rt-ax58u_v2",   sdk: "src-rt-5.04axhnd.675x", ui: "default",  skip: false }
       container:
-        image: gnuton/asuswrt-merlin-toolchains-docker:latest
+        image: gnuton/asuswrt-merlin-toolchains-docker:latest-ubuntu-20_04
         env:
           MERLINUPDATE: "y"
           MODEL: ${{ matrix.cfg.model }}

--- a/release/src/router/www/Advanced_FirmwareUpgrade_Content.asp
+++ b/release/src/router/www/Advanced_FirmwareUpgrade_Content.asp
@@ -156,6 +156,7 @@ afwupg_support=false;
 betaupg_support=false;
 revertfw_support=false;
 rbkfw_support=false;
+no_fw_manual_support = false;
 
 if(pipefw_support || urlfw_support){
 	var hndwr_status = '<% nvram_get("hndwr"); %>';
@@ -513,7 +514,7 @@ function initial(){
 							$("#amas_" + mac_id + "").children().find(".aimesh_fw_revert_node").remove();
 					}
 
-					if(capability_value & 4096){     //no_fw_manual_support
+					if(false && (capability_value & 4096)){     //no_fw_manual_support
 						$("#amas_" + mac_id + "").children("#manual_firmware_update").empty();
 					}
 					if(capability_value & 8192){     //live_update_support
@@ -660,12 +661,12 @@ function initial(){
 		$(".aimesh_manual_fw_update_hint").css("display", "none");
 	}
 
-	if(is_ISP_incompatible)
+	if(false && is_ISP_incompatible)
 	{
 		$("#fw_note2").show();
 		$("#fw_note2").html("The firmware of ISP (Internet Service Provider) project is not compatible with the ASUS retail models, and also it’s unavailable for firmware manual update.");	//Untranslated
 	}
-	if(isSupport("is_ax5400_i1"))
+	if(false && isSupport("is_ax5400_i1"))
 	{
 		$("#fw_note3").show();
 		$("#fw_note3").html("Firmware upgrade is only accessible through Optus server.");	//Untranslated
@@ -1791,7 +1792,7 @@ function update_AiMesh_fw() {
 						$("#amas_" + mac_id + "").children("#manual_firmware_update").empty();
 						$("#amas_" + mac_id + "").children("#manual_firmware_update").append(gen_AiMesh_fw_status(support_manual_fw, get_cfg_clientlist[idx]));
 					}
-					if(capability_value & 4096){     //no_fw_manual_support
+					if(false && (capability_value & 4096)){     //no_fw_manual_support
 						$("#amas_" + mac_id + "").children("#manual_firmware_update").empty();
 					}
 

--- a/tools/start-build-env.sh
+++ b/tools/start-build-env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker pull gnuton/asuswrt-merlin-toolchains-docker:latest-ubuntu-20_04
+docker pull gnuton/asuswrt-merlin-toolchains-docker:latest
 docker run -it --rm -v "$PWD:/build"  -u "docker:docker" \
-       gnuton/asuswrt-merlin-toolchains-docker:latest-ubuntu-20_04 /bin/bash
+       gnuton/asuswrt-merlin-toolchains-docker:latest /bin/bash
 

--- a/tools/start-build-env.sh
+++ b/tools/start-build-env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker pull gnuton/asuswrt-merlin-toolchains-docker:latest
+docker pull gnuton/asuswrt-merlin-toolchains-docker:latest-ubuntu-20_04
 docker run -it --rm -v "$PWD:/build"  -u "docker:docker" \
-       gnuton/asuswrt-merlin-toolchains-docker:latest /bin/bash
+       gnuton/asuswrt-merlin-toolchains-docker:latest-ubuntu-20_04 /bin/bash
 


### PR DESCRIPTION
Restored the manual firmware upload section on the Firmware Upgrade page for DSL-AX82U/DSL-AX5400 models by bypassing ISP-specific UI locks.

Changes in `release/src/router/www/Advanced_FirmwareUpgrade_Content.asp`:
- Set `no_fw_manual_support = false;` in the Merlin override section.
- Short-circuited the `is_ISP_incompatible` check to prevent the "incompatible with ASUS retail models" warning.
- Short-circuited the `isSupport("is_ax5400_i1")` check to remove the Optus server requirement message.
- Short-circuited `capability_value & 4096` checks in the AiMesh update logic to ensure manual upgrade remains available for nodes.

Fixes #477

---
*PR created automatically by Jules for task [5379080425745851728](https://jules.google.com/task/5379080425745851728) started by @gnuton*