### PR TITLE
Fix PyList_SetItem Use-After-Free reference counting bug in libxml.c

### DIFF
--- a/release/src/router/libxml2/python/libxml.c
+++ b/release/src/router/libxml2/python/libxml.c
@@ -1326,7 +1326,6 @@ pythonAttributeDecl(void *user_data,
         for (node = tree; node != NULL; node = node->next) {
             newName = PY_IMPORT_STRING((char *) node->name);
             PyList_SetItem(nameList, count, newName);
-	    Py_DECREF(newName);
             count++;
         }
         result = PyObject_CallMethod(handler, (char *) "attributeDecl",


### PR DESCRIPTION
Port upstream GNOME/libxml2 commit 046931e to fix reference counting (use-after-free) bug in PyList_SetItem within libxml.c.

Fixes #957

---
*PR created automatically by Jules for task [17548187534856991740](https://jules.google.com/task/17548187534856991740) started by @gnuton*