### PR TITLE
rc: preserve aurargb_enable across reboots

### DIFF
--- a/release/src/router/rc/init.c
+++ b/release/src/router/rc/init.c
@@ -22095,11 +22095,6 @@ void reset_button_state(void) {
 		nvram_set("AllLED", "1");
 #endif
 
-#if defined(RTCONFIG_TURBO_BTN) && defined(RTCONFIG_RGBLED)
-	if(!nvram_match("aurargb_enable", "1"))
-		nvram_set("aurargb_enable", "1");
-#endif
-
 #if defined(RTCONFIG_WIFI_TOG_BTN)
 	char tmp[100], prefix[] = "wlXXXXXXXXXXXXXX";
 	int i;


### PR DESCRIPTION
Fix issue where Aura RGB lighting is forced back on after a router reboot even if disabled in settings.

Fixes #985

---
*PR created automatically by Jules for task [4356216756764323134](https://jules.google.com/task/4356216756764323134) started by @gnuton*