### PR TITLE
Add Web UI Theme Support Proof of Concept

### DIFF
--- a/release/src/router/shared/defaults.c
+++ b/release/src/router/shared/defaults.c
@@ -37,6 +37,7 @@ struct nvram_tuple router_defaults[] = {
 	{ "ASUS_EULA", "0", CKN_STR1, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },
 	{ "ASUS_NEW_EULA", "0", CKN_STR1, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },
 	{ "preferred_lang", "EN", CKN_STR2, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },
+	{ "ui_theme", "0", CKN_STR1, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },
 
 	// NVRAM from init_nvram: system wide parameters accodring to model and mode
 	//{ "wan_ifnames", "" },

--- a/release/src/router/www/Advanced_System_Content.asp
+++ b/release/src/router/www/Advanced_System_Content.asp
@@ -2360,6 +2360,7 @@ function build_boostkey_options() {
 <input type="hidden" name="action_script" value="restart_time;restart_httpd;restart_upnp">
 <input type="hidden" name="first_time" value="">
 <input type="hidden" name="preferred_lang" id="preferred_lang" value="<% nvram_get("preferred_lang"); %>">
+<input type="hidden" name="ui_theme" id="ui_theme" value="<% nvram_get("ui_theme"); %>">
 <input type="hidden" name="firmver" value="<% nvram_get("firmver"); %>">
 <input type="hidden" name="time_zone_dst" value="<% nvram_get("time_zone_dst"); %>">
 <input type="hidden" name="time_zone" value="<% nvram_get("time_zone"); %>">
@@ -2523,6 +2524,15 @@ function build_boostkey_options() {
 						<input type="radio" name="ntpd_server_redir" value="1" <% nvram_match_x("","ntpd_server_redir","1", "checked"); %> ><#checkbox_Yes#>
 						<input type="radio" name="ntpd_server_redir" value="0" <% nvram_match_x("","ntpd_server_redir","0", "checked"); %> ><#checkbox_No#>
 					</td>
+				<tr>
+					<th>Web UI Theme</th>
+					<td>
+						<select name="ui_theme_select" id="ui_theme_select" class="input_option" onchange="document.form.ui_theme.value = this.value;">
+							<option value="0" <% nvram_match("ui_theme", "0", "selected"); %>>Default</option>
+							<option value="1" <% nvram_match("ui_theme", "1", "selected"); %>>Blue Theme</option>
+						</select>
+					</td>
+				</tr>
 				<tr>
 					<th><a class="hintstyle"  href="javascript:void(0);" onClick="openHint(11,2)"><#LANHostConfig_x_TimeZone_itemname#></a></th>
 					<td>

--- a/release/src/router/www/css/theme_blue.css
+++ b/release/src/router/www/css/theme_blue.css
@@ -1,0 +1,21 @@
+/* Sample Theme Stylesheet: Blue Theme (Theme 1) */
+
+body {
+    background-color: #0b192c !important;
+    color: #e0e6ed !important;
+}
+
+.FormTable {
+    background-color: #112240 !important;
+    border-color: #1e3a8a !important;
+}
+
+.button_gen {
+    background-color: #1d4ed8 !important;
+    border-color: #2563eb !important;
+    color: #ffffff !important;
+}
+
+.button_gen:hover {
+    background-color: #2563eb !important;
+}

--- a/release/src/router/www/state.js
+++ b/release/src/router/www/state.js
@@ -864,6 +864,10 @@ var le_restart_httpd_chk = "";
 
 var wifison_ready = '<% nvram_get("wifison_ready"); %>';
 var ui_lang = '<% nvram_get("preferred_lang"); %>';
+var ui_theme = '<% nvram_get("ui_theme"); %>';
+if(ui_theme == "1"){
+	addNewCSS("/css/theme_blue.css");
+}
 
 if(lyra_hide_support){
 	var Android_app_link = "https://play.google.com/store/apps/details?id=com.asus.hive";


### PR DESCRIPTION
Proof of concept for Web UI theme support including NVRAM default, theme selector UI setting, dynamic CSS loading in state.js, and a sample blue theme stylesheet.

Fixes #72

---
*PR created automatically by Jules for task [16404596189098151310](https://jules.google.com/task/16404596189098151310) started by @gnuton*