### PR TITLE
Fix static route limit by increasing NVRAM and firewall route buffer sizes

### DIFF
--- a/release/src/router/rc/firewall.c
+++ b/release/src/router/rc/firewall.c
@@ -1048,9 +1048,9 @@ void convert_routes(void)
 	char tmp[100], prefix[] = "wanXXXXXXXXXX_";
 	char *nv, *nvp, *b;
 	char *ip, *netmask, *gateway, *metric, *interface;
-	char wroutes[1024], lroutes[1024], mroutes[1024];
+	char wroutes[4096], lroutes[4096], mroutes[4096];
 #ifdef RTCONFIG_VPNC
-	char vroutes[1024];
+	char vroutes[4096];
 #endif
 	int wan_max_unit = WAN_UNIT_MAX;
 

--- a/release/src/router/shared/defaults.c
+++ b/release/src/router/shared/defaults.c
@@ -1975,7 +1975,7 @@ struct nvram_tuple router_defaults[] = {
 #endif
 #endif
 #endif // RTCONFIG_LACP
-	{ "lan_route", "", CKN_STR_DEFAULT, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },	/* Static routes (ipaddr:netmask:gateway:metric:ifname ...) */
+	{ "lan_route", "", CKN_STR4096, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },	/* Static routes (ipaddr:netmask:gateway:metric:ifname ...) */
 
 #if defined(RTCONFIG_DEFAULT_AP_MODE) || defined(RTCONFIG_CONCURRENTREPEATER)
 	{ "lan_dnsenable_x", "1", CKN_STR1, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },
@@ -2000,7 +2000,7 @@ struct nvram_tuple router_defaults[] = {
 	{ "lan1_domain", "", CKN_STR32, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },	/* LAN domain name */
 	{ "lan1_lease", "86400", CKN_STR_DEFAULT, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },	/* LAN lease time in seconds */
 	{ "lan1_stp", "1", CKN_STR_DEFAULT, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },	/* LAN spanning tree protocol */
-	{ "lan1_route", "", CKN_STR_DEFAULT, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },	/* Static routes (ipaddr:netmask:gateway:metric:ifname ...) */
+	{ "lan1_route", "", CKN_STR4096, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },	/* Static routes (ipaddr:netmask:gateway:metric:ifname ...) */
 
 	// NVRAM for start_dhcpd
 	// DHCP server parameters
@@ -2057,7 +2057,7 @@ struct nvram_tuple router_defaults[] = {
 
 	// NVRAM for do_startic_routes
 	{ "sr_enable_x", "0", CKN_STR1, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },
-	{ "sr_rulelist", "", CKN_STR1024, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },
+	{ "sr_rulelist", "", CKN_STR4096, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },
 	{ "dr_enable_x", "1", CKN_STR1, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },	/* oleg patch */
 	{ "mr_enable_x", "0", CKN_STR1, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },	/* 0:disable, 1:igmp, 2:mld, 3:igmp+mld */
 	{ "mr_qleave_x", "0", CKN_STR1, CKN_TYPE_DEFAULT, CKN_ACC_LEVEL_DEFAULT, CKN_ENC_DEFAULT, 0 },


### PR DESCRIPTION
Fix issue where static routes could not be added past ~24 rules due to NVRAM string length constraint (1024 bytes) and buffer truncation in convert_routes(). Increased sr_rulelist, lan_route, and lan1_route size limits to 4096 bytes and enlarged internal route buffers in firewall.c.

Fixes #944

---
*PR created automatically by Jules for task [15912223432624627982](https://jules.google.com/task/15912223432624627982) started by @gnuton*