### PR TITLE
Fix PPPoE NAT MASQUERADE, captive portal redirect, and port forwarding on RT-AX5400

### DIFF
--- a/release/src/router/rc/firewall.c
+++ b/release/src/router/rc/firewall.c
@@ -2700,11 +2700,13 @@ void redirect_setting(void)
 	add_nat_rule_for_gpon_sfp_module(redirect_fp);
 #endif
 
-	fprintf(redirect_fp,
-		"-A PREROUTING ! -d %s -p tcp --dport 80 -j DNAT --to-destination %s:18017\n"
-		"-A PREROUTING -p udp --dport 53 -j DNAT --to-destination %s:18018\n",
-		lan_class, lan_ipaddr_t,
-		lan_ipaddr_t);
+	if (is_nat_enabled() && nvram_match("x_Setting", "0")) {
+		fprintf(redirect_fp,
+			"-A PREROUTING ! -d %s -p tcp --dport 80 -j DNAT --to-destination %s:18017\n"
+			"-A PREROUTING -p udp --dport 53 -j DNAT --to-destination %s:18018\n",
+			lan_class, lan_ipaddr_t,
+			lan_ipaddr_t);
+	}
 #ifdef RTCONFIG_YANDEXDNS
 	fprintf(redirect_fp,
 		"-I YADNS 1 -p udp -j DNAT --to-destination %s:18018\n", lan_ipaddr_t);

--- a/release/src/router/shared/misc.c
+++ b/release/src/router/shared/misc.c
@@ -1877,6 +1877,9 @@ int get_wan_proto(char *prefix)
 	int i;
 
 	strlcpy(proto, nvram_safe_get(strlcat_r(prefix, "proto", tmp, sizeof(tmp))), sizeof(proto));
+	if (*proto == '\0') {
+		strlcpy(proto, nvram_safe_get("wan_proto"), sizeof(proto));
+	}
 	for (i = 0; services[i].name; i++) {
 		if (strcmp(proto, services[i].name) == 0)
 			return services[i].service;

--- a/release/src/router/shared/rtstate.c
+++ b/release/src/router/shared/rtstate.c
@@ -98,7 +98,12 @@ int is_nat_enabled(void)
 	} else {
 		/* Single WAN/Dual WAN FO/FB, check primary WAN unit only. */
 		snprintf(prefix, sizeof(prefix), "wan%d_", wan_primary_ifunit());
-		nr_nat = nvram_pf_get_int(prefix, "nat_x");
+		if (nvram_pf_get(prefix, "nat_x"))
+			nr_nat = nvram_pf_get_int(prefix, "nat_x");
+		else if (nvram_get("wan_nat_x"))
+			nr_nat = nvram_get_int("wan_nat_x");
+		else
+			nr_nat = 1;
 	}
 
 	return (nr_nat > 0)? 1 : 0;
@@ -387,6 +392,9 @@ char *get_wan_ifname(int unit)
 	case WAN_MAPE:
 #endif
 		wan_ifname = nvram_safe_get(strlcat_r(prefix, "pppoe_ifname", tmp, sizeof(tmp)));
+		if (*wan_ifname == '\0') {
+			wan_ifname = nvram_safe_get("pppoe_ifname");
+		}
 		break;
 #ifdef RTCONFIG_SOFTWIRE46
 	case WAN_V6PLUS:
@@ -395,11 +403,17 @@ char *get_wan_ifname(int unit)
 	case WAN_DSLITE:
 		if (nvram_pf_get_int(prefix, "s46_hgw_case") >= S46_CASE_MAP_HGW_OFF) {
 			wan_ifname = nvram_safe_get(strlcat_r(prefix, "pppoe_ifname", tmp, sizeof(tmp)));
+			if (*wan_ifname == '\0') {
+				wan_ifname = nvram_safe_get("pppoe_ifname");
+			}
 			break;
 		}
 #endif
 	default:
 		wan_ifname = nvram_safe_get(strlcat_r(prefix, "ifname", tmp, sizeof(tmp)));
+		if (*wan_ifname == '\0') {
+			wan_ifname = nvram_safe_get("wan_ifname");
+		}
 		break;
 	}
 

--- a/release/src/router/shared/rtstate.h
+++ b/release/src/router/shared/rtstate.h
@@ -447,7 +447,7 @@ typedef struct _MOCA_MIB_DATA
 #if defined(RTCONFIG_DUALWAN)
 extern int is_nat_enabled(void);
 #else
-#define is_nat_enabled()     ((sw_mode()==SW_MODE_ROUTER||sw_mode()==SW_MODE_HOTSPOT)&&nvram_get_int("wan0_nat_x")==1)
+#define is_nat_enabled()     ((sw_mode()==SW_MODE_ROUTER||sw_mode()==SW_MODE_HOTSPOT)&&(nvram_get("wan0_nat_x") ? nvram_get_int("wan0_nat_x") : (nvram_get("wan_nat_x") ? nvram_get_int("wan_nat_x") : 1))==1)
 #endif
 #define is_lan_connected()   (nvram_get_int("lan_state")==LAN_STATE_CONNECTED)
 #ifdef RTCONFIG_WIRELESSWAN


### PR DESCRIPTION
Fixes three issues affecting PPPoE WAN connections on RT-AX5400: missing MASQUERADE rule in POSTROUTING, rogue captive portal redirect rules in PREROUTING when DNS Filter is disabled, and port forwarding rules failing to apply to ppp0 interface.

Fixes #960

---
*PR created automatically by Jules for task [987113072700650723](https://jules.google.com/task/987113072700650723) started by @gnuton*